### PR TITLE
Fixed bug running tests on windows

### DIFF
--- a/src/tests/test_data_request_output.py
+++ b/src/tests/test_data_request_output.py
@@ -221,6 +221,7 @@ class TestDataRequestOutput(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tdir:
             outdir = Path(tdir)
             fname = outdir / 'writeNetCDF.nc'
+            print("\n fname: ", fname,"\n")
 
             # Point data
             dro._writeNetCDF(self.test_gdf, fname)
@@ -252,7 +253,7 @@ class TestDataRequestOutput(unittest.TestCase):
             exp_nan = np.isnan(exp_vals)
             r_nan = np.isnan(r_vals)
             self.assertTrue((same | (exp_nan & r_nan)).all())
-
+            r.close()
 
     def test_writeGeoTIFF(self):
         pass

--- a/src/tests/test_data_request_output.py
+++ b/src/tests/test_data_request_output.py
@@ -221,7 +221,6 @@ class TestDataRequestOutput(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tdir:
             outdir = Path(tdir)
             fname = outdir / 'writeNetCDF.nc'
-            print("\n fname: ", fname,"\n")
 
             # Point data
             dro._writeNetCDF(self.test_gdf, fname)

--- a/src/tests/test_upload_cache.py
+++ b/src/tests/test_upload_cache.py
@@ -90,7 +90,7 @@ class TestDataUploadCache(unittest.TestCase):
 
         exp = 'data/upload_cache/csv_1.csv'
         r = uc._getCacheFile('csv_1')
-        self.assertEqual(exp, str(r))
+        self.assertEqual(Path(exp), Path(r))
 
         # Test an invalid GUID.
         with self.assertRaisesRegex(Exception, 'No cached .* data found'):


### PR DESCRIPTION
`test_data_request_output.py` produced PermissionError on windows when deleting a temp directory with an open file. File now closed before deleting directory.

`test_upload_cache.py` compared two path names by comparing literal strings, which caused errors when running on windows. File now uses pathlib.Path to compare path names.